### PR TITLE
feat(auth): bearer token filter + UI login/register

### DIFF
--- a/src/main/java/is/hi/basketmob/config/SecurityConfig.java
+++ b/src/main/java/is/hi/basketmob/config/SecurityConfig.java
@@ -1,20 +1,52 @@
 package is.hi.basketmob.config;
 
+import is.hi.basketmob.security.AuthTokenFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
+    private final AuthTokenFilter authTokenFilter;
+
+    public SecurityConfig(AuthTokenFilter authTokenFilter) {
+        this.authTokenFilter = authTokenFilter;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // MVP: everything open; CSRF off for simple POST from Swagger/PowerShell
         http.csrf().disable()
-                .authorizeRequests(a -> a.anyRequest().permitAll());
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeRequests(registry -> registry
+                        .antMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .antMatchers(
+                                "/api/v1/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/",
+                                "/index",
+                                "/games",
+                                "/standings",
+                                "/login",
+                                "/register",
+                                "/favorites",
+                                "/css/**",
+                                "/js/**",
+                                "/images/**",
+                                "/favicon.ico"
+                        ).permitAll()
+                        .antMatchers(HttpMethod.GET, "/api/v1/games/**", "/api/v1/standings/**", "/api/v1/leagues/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(authTokenFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 

--- a/src/main/java/is/hi/basketmob/controller/UiAuthController.java
+++ b/src/main/java/is/hi/basketmob/controller/UiAuthController.java
@@ -1,0 +1,136 @@
+package is.hi.basketmob.controller;
+
+import is.hi.basketmob.dto.LoginForm;
+import is.hi.basketmob.dto.RegisterForm;
+import is.hi.basketmob.entity.User;
+import is.hi.basketmob.repository.UserRepository;
+import is.hi.basketmob.security.AuthenticatedUser;
+import is.hi.basketmob.service.AuthTokenService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Controller
+public class UiAuthController {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthTokenService authTokenService;
+
+    public UiAuthController(UserRepository userRepository,
+                            PasswordEncoder passwordEncoder,
+                            AuthTokenService authTokenService) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.authTokenService = authTokenService;
+    }
+
+    @GetMapping("/login")
+    public String loginForm(@AuthenticationPrincipal AuthenticatedUser user, Model model) {
+        if (user != null) {
+            return "redirect:/dashboard";
+        }
+        if (!model.containsAttribute("loginForm")) {
+            model.addAttribute("loginForm", new LoginForm());
+        }
+        return "login";
+    }
+
+    @PostMapping("/login")
+    public String doLogin(@Valid @ModelAttribute("loginForm") LoginForm form,
+                          BindingResult result,
+                          HttpServletResponse response,
+                          RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            return "login";
+        }
+
+        var userOpt = userRepository.findByEmail(form.getEmail());
+        if (userOpt.isEmpty() || !passwordEncoder.matches(form.getPassword(), userOpt.get().getPassword())) {
+            result.reject("invalid", "Vitlaus innskráningarupplýsing");
+            return "login";
+        }
+
+        User user = userOpt.get();
+        issueCookie(user, response);
+        redirectAttributes.addFlashAttribute("toast", "Velkomin(n) " + user.getDisplayName());
+        return "redirect:/dashboard";
+    }
+
+    @GetMapping("/register")
+    public String registerForm(@AuthenticationPrincipal AuthenticatedUser user, Model model) {
+        if (user != null) {
+            return "redirect:/dashboard";
+        }
+        if (!model.containsAttribute("registerForm")) {
+            model.addAttribute("registerForm", new RegisterForm());
+        }
+        return "register";
+    }
+
+    @PostMapping("/register")
+    public String register(@Valid @ModelAttribute("registerForm") RegisterForm form,
+                           BindingResult result,
+                           HttpServletResponse response,
+                           RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            return "register";
+        }
+
+        if (userRepository.findByEmail(form.getEmail()).isPresent()) {
+            result.rejectValue("email", "duplicate", "Netfang er þegar í notkun");
+            return "register";
+        }
+
+        OffsetDateTime nowUtc = OffsetDateTime.now(ZoneOffset.UTC);
+        User user = new User();
+        user.setEmail(form.getEmail());
+        user.setPassword(passwordEncoder.encode(form.getPassword()));
+        user.setDisplayName(form.getDisplayName());
+        user.setCreatedAt(nowUtc);
+        user.setUpdatedAt(nowUtc);
+        user = userRepository.save(user);
+
+        issueCookie(user, response);
+        redirectAttributes.addFlashAttribute("toast", "Nýskráning tókst – velkomin(n)!");
+        return "redirect:/dashboard";
+    }
+
+    @PostMapping("/logout")
+    public String logout(HttpServletResponse response, RedirectAttributes redirectAttributes) {
+        ResponseCookie cookie = ResponseCookie.from("BM_TOKEN", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        redirectAttributes.addFlashAttribute("toast", "Útskráning tókst");
+        return "redirect:/";
+    }
+
+    private void issueCookie(User user, HttpServletResponse response) {
+        String token = authTokenService.issueToken(user.getId(), user.isAdmin());
+        ResponseCookie cookie = ResponseCookie.from("BM_TOKEN", token)
+                .path("/")
+                .maxAge(Duration.ofDays(1))
+                .httpOnly(true)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/is/hi/basketmob/controller/UiModelAttributes.java
+++ b/src/main/java/is/hi/basketmob/controller/UiModelAttributes.java
@@ -1,0 +1,15 @@
+package is.hi.basketmob.controller;
+
+import is.hi.basketmob.security.AuthenticatedUser;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class UiModelAttributes {
+
+    @ModelAttribute("currentUser")
+    public AuthenticatedUser currentUser(@AuthenticationPrincipal AuthenticatedUser user) {
+        return user;
+    }
+}

--- a/src/main/java/is/hi/basketmob/controller/UserController.java
+++ b/src/main/java/is/hi/basketmob/controller/UserController.java
@@ -2,11 +2,19 @@ package is.hi.basketmob.controller;
 
 import is.hi.basketmob.dto.UserResponse;
 import is.hi.basketmob.dto.UserUpdateRequest;
-import is.hi.basketmob.entity.User;
 import is.hi.basketmob.mapper.UserMapper;
+import is.hi.basketmob.security.AuthenticatedUser;
 import is.hi.basketmob.service.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
@@ -23,34 +31,58 @@ public class UserController {
     @PutMapping("/{id}")
     public ResponseEntity<UserResponse> putUpdate(
             @PathVariable Long id,
-            @Valid @RequestBody UserUpdateRequest body
+            @Valid @RequestBody UserUpdateRequest body,
+            @AuthenticationPrincipal AuthenticatedUser actor
     ) {
-        User updated = userService.updateUser(id, body, /*actorUserId*/ id, /*actorIsAdmin*/ false, /*isPut*/ true);
-        return ResponseEntity.ok(UserMapper.toResponse(updated));
+        return ResponseEntity.ok(
+                UserMapper.toResponse(userService.updateUser(id, body, actor.getId(), actor.isAdmin(), true))
+        );
     }
 
 
     @PatchMapping("/{id}")
     public ResponseEntity<UserResponse> patchUpdate(
             @PathVariable Long id,
-            @RequestBody UserUpdateRequest body
+            @RequestBody UserUpdateRequest body,
+            @AuthenticationPrincipal AuthenticatedUser actor
     ) {
-        User updated = userService.updateUser(id, body, /*actorUserId*/ id, /*actorIsAdmin*/ false, /*isPut*/ false);
-        return ResponseEntity.ok(UserMapper.toResponse(updated));
+        return ResponseEntity.ok(
+                UserMapper.toResponse(userService.updateUser(id, body, actor.getId(), actor.isAdmin(), false))
+        );
     }
 
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        userService.deleteUser(id, /*actorUserId*/ id, /*actorIsAdmin*/ false);
+    public ResponseEntity<Void> delete(@PathVariable Long id,
+                                       @AuthenticationPrincipal AuthenticatedUser actor) {
+        userService.deleteUser(id, actor.getId(), actor.isAdmin());
         return ResponseEntity.noContent().build();
     }
-        @GetMapping("/me")
-        public ResponseEntity<UserResponse> me() {
 
-            var u = userService.findByEmail("tomas@example.com");
-            return ResponseEntity.ok(UserMapper.toResponse(u));
-        }
-
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> me(@AuthenticationPrincipal AuthenticatedUser actor) {
+        return ResponseEntity.ok(UserMapper.toResponse(userService.findById(actor.getId())));
     }
 
+    @PutMapping("/me")
+    public ResponseEntity<UserResponse> putMe(@Valid @RequestBody UserUpdateRequest body,
+                                              @AuthenticationPrincipal AuthenticatedUser actor) {
+        return ResponseEntity.ok(
+                UserMapper.toResponse(userService.updateUser(actor.getId(), body, actor.getId(), actor.isAdmin(), true))
+        );
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<UserResponse> patchMe(@RequestBody UserUpdateRequest body,
+                                                @AuthenticationPrincipal AuthenticatedUser actor) {
+        return ResponseEntity.ok(
+                UserMapper.toResponse(userService.updateUser(actor.getId(), body, actor.getId(), actor.isAdmin(), false))
+        );
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(@AuthenticationPrincipal AuthenticatedUser actor) {
+        userService.deleteUser(actor.getId(), actor.getId(), actor.isAdmin());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/is/hi/basketmob/dto/LoginForm.java
+++ b/src/main/java/is/hi/basketmob/dto/LoginForm.java
@@ -1,0 +1,30 @@
+package is.hi.basketmob.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public class LoginForm {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/is/hi/basketmob/dto/RegisterForm.java
+++ b/src/main/java/is/hi/basketmob/dto/RegisterForm.java
@@ -1,0 +1,44 @@
+package is.hi.basketmob.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class RegisterForm {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(min = 8, max = 200)
+    private String password;
+
+    @NotBlank
+    @Size(min = 2, max = 50)
+    private String displayName;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/is/hi/basketmob/dto/UserResponse.java
+++ b/src/main/java/is/hi/basketmob/dto/UserResponse.java
@@ -6,10 +6,16 @@ public class UserResponse {
     public String displayName;
     public String avatarUrl;
     public String gender;
+    public boolean admin;
 
     public UserResponse() {}
-    public UserResponse(Long id, String email, String displayName, String avatarUrl, String gender) {
-        this.id = id; this.email = email; this.displayName = displayName; this.avatarUrl = avatarUrl; this.gender = gender;
+    public UserResponse(Long id, String email, String displayName, String avatarUrl, String gender, boolean admin) {
+        this.id = id;
+        this.email = email;
+        this.displayName = displayName;
+        this.avatarUrl = avatarUrl;
+        this.gender = gender;
+        this.admin = admin;
     }
 }
 

--- a/src/main/java/is/hi/basketmob/entity/Notification.java
+++ b/src/main/java/is/hi/basketmob/entity/Notification.java
@@ -1,0 +1,80 @@
+package is.hi.basketmob.entity;
+
+import javax.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Game game;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(nullable = false)
+    private boolean readFlag = false;
+
+    @Column(nullable = false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    public Notification() {}
+
+    public Notification(User user, Game game, String message) {
+        this.user = user;
+        this.game = game;
+        this.message = message;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Game getGame() {
+        return game;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isReadFlag() {
+        return readFlag;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public void setGame(Game game) {
+        this.game = game;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public void setReadFlag(boolean readFlag) {
+        this.readFlag = readFlag;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/is/hi/basketmob/entity/User.java
+++ b/src/main/java/is/hi/basketmob/entity/User.java
@@ -25,6 +25,9 @@ public class User {
     @Column(length = 20)
     private String gender; // e.g., male | female | other
 
+    @Column(nullable = false)
+    private boolean admin = false;
+
     @Column(nullable = false, columnDefinition = "timestamp")
     private OffsetDateTime createdAt = OffsetDateTime.now();
 
@@ -49,6 +52,9 @@ public class User {
 
     public String getGender() { return gender; }
     public void setGender(String gender) { this.gender = gender; }
+
+    public boolean isAdmin() { return admin; }
+    public void setAdmin(boolean admin) { this.admin = admin; }
 
     public OffsetDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/is/hi/basketmob/mapper/UserMapper.java
+++ b/src/main/java/is/hi/basketmob/mapper/UserMapper.java
@@ -6,7 +6,14 @@ import is.hi.basketmob.entity.User;
 public final class UserMapper {
     private UserMapper() {}
     public static UserResponse toResponse(User u) {
-        return new UserResponse(u.getId(), u.getEmail(), u.getDisplayName(), u.getAvatarUrl(), u.getGender());
+        return new UserResponse(
+                u.getId(),
+                u.getEmail(),
+                u.getDisplayName(),
+                u.getAvatarUrl(),
+                u.getGender(),
+                u.isAdmin()
+        );
     }
 }
 

--- a/src/main/java/is/hi/basketmob/notification/GameUpdateObserver.java
+++ b/src/main/java/is/hi/basketmob/notification/GameUpdateObserver.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.notification;
+
+import is.hi.basketmob.entity.Game;
+
+public interface GameUpdateObserver {
+    void onGameFinal(Game game);
+}

--- a/src/main/java/is/hi/basketmob/notification/GameUpdatePublisher.java
+++ b/src/main/java/is/hi/basketmob/notification/GameUpdatePublisher.java
@@ -1,0 +1,21 @@
+package is.hi.basketmob.notification;
+
+import is.hi.basketmob.entity.Game;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+public class GameUpdatePublisher {
+
+    private final List<GameUpdateObserver> observers = new CopyOnWriteArrayList<>();
+
+    public void register(GameUpdateObserver observer) {
+        observers.add(observer);
+    }
+
+    public void notifyFinal(Game game) {
+        observers.forEach(observer -> observer.onGameFinal(game));
+    }
+}

--- a/src/main/java/is/hi/basketmob/repository/NotificationRepository.java
+++ b/src/main/java/is/hi/basketmob/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.repository;
+
+import is.hi.basketmob.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/is/hi/basketmob/security/AuthTokenFilter.java
+++ b/src/main/java/is/hi/basketmob/security/AuthTokenFilter.java
@@ -1,0 +1,80 @@
+package is.hi.basketmob.security;
+
+import is.hi.basketmob.repository.UserRepository;
+import is.hi.basketmob.service.AuthTokenService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class AuthTokenFilter extends OncePerRequestFilter {
+
+    private final AuthTokenService tokenService;
+    private final UserRepository userRepository;
+
+    public AuthTokenFilter(AuthTokenService tokenService, UserRepository userRepository) {
+        this.tokenService = tokenService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        tryResolveUser(request);
+        filterChain.doFilter(request, response);
+    }
+
+    private void tryResolveUser(HttpServletRequest request) {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            return;
+        }
+
+        String token = resolveToken(request);
+        if (!StringUtils.hasText(token)) {
+            return;
+        }
+
+        tokenService.resolve(token).ifPresentOrElse(session -> {
+            userRepository.findById(session.userId()).ifPresentOrElse(user -> {
+                AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), user.isAdmin());
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }, () -> tokenService.revoke(token));
+        }, () -> tokenService.revoke(token));
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7).trim();
+        }
+        String fallback = request.getHeader("X-Auth-Token");
+        if (StringUtils.hasText(fallback)) {
+            return fallback.trim();
+        }
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("BM_TOKEN".equals(cookie.getName()) && StringUtils.hasText(cookie.getValue())) {
+                    return cookie.getValue().trim();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/is/hi/basketmob/security/AuthenticatedUser.java
+++ b/src/main/java/is/hi/basketmob/security/AuthenticatedUser.java
@@ -1,0 +1,72 @@
+package is.hi.basketmob.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Authentication principal exposed through Spring Security.
+ */
+public class AuthenticatedUser implements UserDetails {
+    private final Long id;
+    private final String email;
+    private final boolean admin;
+
+    public AuthenticatedUser(Long id, String email, boolean admin) {
+        this.id = id;
+        this.email = email;
+        this.admin = admin;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public boolean isAdmin() {
+        return admin;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        if (admin) {
+            return List.of(
+                    new SimpleGrantedAuthority("ROLE_USER"),
+                    new SimpleGrantedAuthority("ROLE_ADMIN")
+            );
+        }
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/GameSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/GameSeed.java
@@ -1,0 +1,58 @@
+package is.hi.basketmob.seed;
+
+public class GameSeed {
+    private String home;
+    private String away;
+    private String tipoff;
+    private String status;
+    private Integer homeScore;
+    private Integer awayScore;
+
+    public String getHome() {
+        return home;
+    }
+
+    public void setHome(String home) {
+        this.home = home;
+    }
+
+    public String getAway() {
+        return away;
+    }
+
+    public void setAway(String away) {
+        this.away = away;
+    }
+
+    public String getTipoff() {
+        return tipoff;
+    }
+
+    public void setTipoff(String tipoff) {
+        this.tipoff = tipoff;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getHomeScore() {
+        return homeScore;
+    }
+
+    public void setHomeScore(Integer homeScore) {
+        this.homeScore = homeScore;
+    }
+
+    public Integer getAwayScore() {
+        return awayScore;
+    }
+
+    public void setAwayScore(Integer awayScore) {
+        this.awayScore = awayScore;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueDataClient.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueDataClient.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public interface LeagueDataClient {
+    List<LeagueSeed> loadLeagues();
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueSeed.java
@@ -1,0 +1,42 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public class LeagueSeed {
+    private String name;
+    private String season;
+    private List<TeamSeed> teams;
+    private List<GameSeed> games;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSeason() {
+        return season;
+    }
+
+    public void setSeason(String season) {
+        this.season = season;
+    }
+
+    public List<TeamSeed> getTeams() {
+        return teams;
+    }
+
+    public void setTeams(List<TeamSeed> teams) {
+        this.teams = teams;
+    }
+
+    public List<GameSeed> getGames() {
+        return games;
+    }
+
+    public void setGames(List<GameSeed> games) {
+        this.games = games;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueSeedData.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueSeedData.java
@@ -1,0 +1,15 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public class LeagueSeedData {
+    private List<LeagueSeed> leagues;
+
+    public List<LeagueSeed> getLeagues() {
+        return leagues;
+    }
+
+    public void setLeagues(List<LeagueSeed> leagues) {
+        this.leagues = leagues;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LocalJsonLeagueDataClient.java
+++ b/src/main/java/is/hi/basketmob/seed/LocalJsonLeagueDataClient.java
@@ -1,0 +1,30 @@
+package is.hi.basketmob.seed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class LocalJsonLeagueDataClient implements LeagueDataClient {
+
+    private final ObjectMapper objectMapper;
+
+    public LocalJsonLeagueDataClient(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<LeagueSeed> loadLeagues() {
+        try (InputStream is = new ClassPathResource("data/dominos-2025.json").getInputStream()) {
+            LeagueSeedData data = objectMapper.readValue(is, LeagueSeedData.class);
+            return data.getLeagues() == null ? Collections.emptyList() : data.getLeagues();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load league seed data", e);
+        }
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/TeamSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/TeamSeed.java
@@ -1,0 +1,40 @@
+package is.hi.basketmob.seed;
+
+public class TeamSeed {
+    private String name;
+    private String shortName;
+    private String city;
+    private String logo;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getLogo() {
+        return logo;
+    }
+
+    public void setLogo(String logo) {
+        this.logo = logo;
+    }
+}

--- a/src/main/java/is/hi/basketmob/service/AuthTokenService.java
+++ b/src/main/java/is/hi/basketmob/service/AuthTokenService.java
@@ -2,22 +2,41 @@ package is.hi.basketmob.service;
 
 import org.springframework.stereotype.Service;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class AuthTokenService {
 
-    private final Map<String, Long> tokens = new ConcurrentHashMap<>();
+    public record AuthSession(Long userId, boolean admin, OffsetDateTime expiresAt) {}
 
-    public String issueToken(Long userId) {
+    private final Map<String, AuthSession> tokens = new ConcurrentHashMap<>();
+
+    public String issueToken(Long userId, boolean admin) {
         String token = UUID.randomUUID().toString();
-        tokens.put(token, userId);
+        OffsetDateTime expires = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1);
+        tokens.put(token, new AuthSession(userId, admin, expires));
         return token;
     }
 
-    public Long resolveUserId(String token) {
-        return tokens.get(token);
+    public Optional<AuthSession> resolve(String token) {
+        if (token == null) return Optional.empty();
+        AuthSession session = tokens.get(token);
+        if (session == null) return Optional.empty();
+        if (session.expiresAt().isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
+            tokens.remove(token);
+            return Optional.empty();
+        }
+        return Optional.of(session);
+    }
+
+    public void revoke(String token) {
+        if (token != null) {
+            tokens.remove(token);
+        }
     }
 }

--- a/src/main/java/is/hi/basketmob/service/FavoriteService.java
+++ b/src/main/java/is/hi/basketmob/service/FavoriteService.java
@@ -38,7 +38,7 @@ public class FavoriteService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ALREADY_FAVORITED");
         }
         favorites.save(new Favorite(u, t));
-        return new TeamDto(t.getId(), t.getName());
+        return toTeamDto(t);
     }
 
     @Transactional
@@ -55,7 +55,17 @@ public class FavoriteService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
 
         return favorites.findByUserId(userId).stream()
-                .map(f -> new TeamDto(f.getTeam().getId(), f.getTeam().getName()))
+                .map(f -> toTeamDto(f.getTeam()))
                 .collect(Collectors.toList());
+    }
+
+    private TeamDto toTeamDto(Team team) {
+        return new TeamDto(
+                team.getId(),
+                team.getName(),
+                team.getShortName(),
+                team.getCity(),
+                team.getLogoUrl()
+        );
     }
 }

--- a/src/main/java/is/hi/basketmob/service/NotificationService.java
+++ b/src/main/java/is/hi/basketmob/service/NotificationService.java
@@ -1,0 +1,56 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.entity.Favorite;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.Notification;
+import is.hi.basketmob.notification.GameUpdateObserver;
+import is.hi.basketmob.notification.GameUpdatePublisher;
+import is.hi.basketmob.repository.FavoriteRepository;
+import is.hi.basketmob.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NotificationService implements GameUpdateObserver {
+
+    private final NotificationRepository notifications;
+    private final FavoriteRepository favorites;
+
+    public NotificationService(NotificationRepository notifications,
+                               FavoriteRepository favorites,
+                               GameUpdatePublisher publisher) {
+        this.notifications = notifications;
+        this.favorites = favorites;
+        publisher.register(this);
+    }
+
+    @Override
+    @Transactional
+    public void onGameFinal(Game game) {
+        List<Long> teamIds = List.of(
+                game.getHomeTeam().getId(),
+                game.getAwayTeam().getId()
+        );
+
+        List<Favorite> followers = favorites.findByTeamIdIn(teamIds);
+        if (followers.isEmpty()) {
+            return;
+        }
+
+        String message = buildMessage(game);
+        for (Favorite follower : followers) {
+            notifications.save(new Notification(follower.getUser(), game, message));
+        }
+    }
+
+    private String buildMessage(Game game) {
+        String vs = game.getHomeTeam().getName() + " vs " + game.getAwayTeam().getName();
+        String score = (game.getHomeScore() != null && game.getAwayScore() != null)
+                ? " (" + game.getHomeScore() + "-" + game.getAwayScore() + ")"
+                : "";
+        return "Final: " + vs + score;
+    }
+}

--- a/src/main/java/is/hi/basketmob/service/StandingsProvider.java
+++ b/src/main/java/is/hi/basketmob/service/StandingsProvider.java
@@ -1,0 +1,12 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.StandingDto;
+
+import java.util.List;
+
+/**
+ * Abstraction for retrieving league standings (allows caching/proxy layers).
+ */
+public interface StandingsProvider {
+    List<StandingDto> getStandings(Long leagueId, String season);
+}

--- a/src/test/java/is/hi/basketmob/service/LeagueServiceTest.java
+++ b/src/test/java/is/hi/basketmob/service/LeagueServiceTest.java
@@ -1,0 +1,107 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.StandingDto;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.repository.GameRepository;
+import is.hi.basketmob.repository.LeagueRepository;
+import is.hi.basketmob.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeagueServiceTest {
+
+    @Mock
+    private LeagueRepository leagueRepository;
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private GameRepository gameRepository;
+
+    private LeagueService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeagueService(leagueRepository, teamRepository, gameRepository);
+    }
+
+    @Test
+    void calculatesStandingsWithExtendedStats() {
+        League league = new League();
+        league.setSeason("2025");
+        ReflectionTestUtils.setField(league, "id", 1L);
+
+        Team valur = new Team();
+        valur.setName("Valur");
+        ReflectionTestUtils.setField(valur, "id", 100L);
+
+        Team kr = new Team();
+        kr.setName("KR");
+        ReflectionTestUtils.setField(kr, "id", 200L);
+
+        when(leagueRepository.findById(1L)).thenReturn(Optional.of(league));
+        when(teamRepository.findByLeagueId(1L)).thenReturn(List.of(valur, kr));
+
+        Game g1 = finalGame(league, valur, kr, 88, 80);
+        Game g2 = finalGame(league, kr, valur, 70, 85);
+        when(gameRepository.findByLeagueIdAndStatus(1L, Game.Status.FINAL)).thenReturn(List.of(g1, g2));
+
+        List<StandingDto> standings = service.getStandings(1L, "2025");
+
+        assertThat(standings).hasSize(2);
+        StandingDto leader = standings.get(0);
+        assertThat(leader.teamName()).isEqualTo("Valur");
+        assertThat(leader.wins()).isEqualTo(2);
+        assertThat(leader.losses()).isZero();
+        assertThat(leader.gamesPlayed()).isEqualTo(2);
+        assertThat(leader.pointsFor()).isEqualTo(173);
+        assertThat(leader.pointsAgainst()).isEqualTo(150);
+        assertThat(leader.winPct()).isEqualTo(1.0d);
+
+        StandingDto runnerUp = standings.get(1);
+        assertThat(runnerUp.teamName()).isEqualTo("KR");
+        assertThat(runnerUp.wins()).isZero();
+        assertThat(runnerUp.losses()).isEqualTo(2);
+        assertThat(runnerUp.pointsFor()).isEqualTo(150);
+    }
+
+    @Test
+    void rejectsSeasonMismatch() {
+        League league = new League();
+        league.setSeason("2025");
+        ReflectionTestUtils.setField(league, "id", 1L);
+        when(leagueRepository.findById(1L)).thenReturn(Optional.of(league));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.getStandings(1L, "2024"));
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private Game finalGame(League league, Team home, Team away, int homeScore, int awayScore) {
+        Game game = new Game();
+        game.setLeague(league);
+        game.setHomeTeam(home);
+        game.setAwayTeam(away);
+        game.setTipoff(LocalDateTime.now());
+        game.setStatus(Game.Status.FINAL);
+        game.setHomeScore(homeScore);
+        game.setAwayScore(awayScore);
+        return game;
+    }
+}

--- a/src/test/java/is/hi/basketmob/service/NotificationServiceTest.java
+++ b/src/test/java/is/hi/basketmob/service/NotificationServiceTest.java
@@ -1,0 +1,86 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.entity.Favorite;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Notification;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.entity.User;
+import is.hi.basketmob.notification.GameUpdatePublisher;
+import is.hi.basketmob.repository.FavoriteRepository;
+import is.hi.basketmob.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    private NotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationService(notificationRepository, favoriteRepository, new GameUpdatePublisher());
+    }
+
+    @Test
+    void createsNotificationForFollowersWhenGameEnds() {
+        Team valur = team(10L, "Valur");
+        Team kr = team(20L, "KR");
+        Game finalGame = new Game();
+        finalGame.setLeague(new League());
+        finalGame.setHomeTeam(valur);
+        finalGame.setAwayTeam(kr);
+        finalGame.setTipoff(LocalDateTime.now());
+        finalGame.setStatus(Game.Status.FINAL);
+        finalGame.setHomeScore(90);
+        finalGame.setAwayScore(82);
+
+        Favorite adminFavorite = new Favorite(user(1L, "admin@basketmob.is"), valur);
+        Favorite tomasFavorite = new Favorite(user(2L, "tomas@example.com"), kr);
+        when(favoriteRepository.findByTeamIdIn(anyList())).thenReturn(List.of(adminFavorite, tomasFavorite));
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.onGameFinal(finalGame);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, times(2)).save(captor.capture());
+        List<Notification> saved = captor.getAllValues();
+        assertThat(saved).hasSize(2);
+        assertThat(saved.get(0).getMessage()).contains("Valur");
+        assertThat(saved.get(0).isReadFlag()).isFalse();
+    }
+
+    private Team team(Long id, String name) {
+        Team team = new Team();
+        team.setName(name);
+        ReflectionTestUtils.setField(team, "id", id);
+        return team;
+    }
+
+    private User user(Long id, String email) {
+        User user = new User();
+        user.setEmail(email);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
feat: auth UI + bearer token filter

> Pair-programming note: Implemented together by @alexa + @tomasandri99 on the same workstation (Nov 8–9). Tomas drove the flow/validation work; I typed and pushed.

## Summary
- Added UiAuthController + UiModelAttributes along with Thymeleaf login/register views and forms.
- Introduced AuthTokenFilter + AuthenticatedUser so UI and API share a bearer-token cookie (BM_TOKEN).
- Surfaced navbar/dashboard states that react to authenticated users.

## Verification
1. ./mvnw clean test
2. ./mvnw spring-boot:run
3. Register/login via UI (or POST /api/v1/auth/register + /login) and confirm protected pages respect the token.

## Remaining gaps / next steps
- REST contract still needs POST /api/v1/users (per A3 scope).
- Tokens live in-memory; will migrate to persistent/JWT store in the next hardening pass.
- `/api/v1/search` endpoint still outstanding.