### PR TITLE
feat(notifications): admin game finalization + follower alerts

### DIFF
--- a/src/main/java/is/hi/basketmob/controller/AdminGameController.java
+++ b/src/main/java/is/hi/basketmob/controller/AdminGameController.java
@@ -1,0 +1,40 @@
+package is.hi.basketmob.controller;
+
+import is.hi.basketmob.dto.GameDto;
+import is.hi.basketmob.dto.GameUpdateRequest;
+import is.hi.basketmob.security.AuthenticatedUser;
+import is.hi.basketmob.service.GameCommandService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.validation.Valid;
+
+@RestController
+@Profile("!stub")
+@RequestMapping("/api/v1/admin/games")
+public class AdminGameController {
+
+    private final GameCommandService commandService;
+
+    public AdminGameController(GameCommandService commandService) {
+        this.commandService = commandService;
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<GameDto> update(@PathVariable Long id,
+                                          @Valid @RequestBody GameUpdateRequest request,
+                                          @AuthenticationPrincipal AuthenticatedUser actor) {
+        if (!actor.isAdmin()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "ADMIN_ONLY");
+        }
+        return ResponseEntity.ok(commandService.updateGame(id, request));
+    }
+}

--- a/src/main/java/is/hi/basketmob/controller/FavoriteController.java
+++ b/src/main/java/is/hi/basketmob/controller/FavoriteController.java
@@ -1,36 +1,44 @@
 package is.hi.basketmob.controller;
 
 import is.hi.basketmob.dto.TeamDto;
+import is.hi.basketmob.security.AuthenticatedUser;
 import is.hi.basketmob.service.FavoriteService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1/me/favorites")
 public class FavoriteController {
     private final FavoriteService favorites;
+
     public FavoriteController(FavoriteService favorites) {
         this.favorites = favorites;
     }
 
-    @GetMapping("/{userId}/favorites")
-    public ResponseEntity<List<TeamDto>> list(@PathVariable Long userId) {
-        return ResponseEntity.ok(favorites.list(userId));
+    @GetMapping
+    public ResponseEntity<List<TeamDto>> list(@AuthenticationPrincipal AuthenticatedUser actor) {
+        return ResponseEntity.ok(favorites.list(actor.getId()));
     }
 
-    // Use query param so you can do /api/v1/users/{id}/favorites?teamId=1
-    @PostMapping("/{userId}/favorites")
-    public ResponseEntity<TeamDto> follow(@PathVariable Long userId,
+    @PostMapping
+    public ResponseEntity<TeamDto> follow(@AuthenticationPrincipal AuthenticatedUser actor,
                                           @RequestParam Long teamId) {
-        return ResponseEntity.ok(favorites.follow(userId, teamId));
+        return ResponseEntity.ok(favorites.follow(actor.getId(), teamId));
     }
 
-    @DeleteMapping("/{userId}/favorites/{teamId}")
-    public ResponseEntity<Void> unfollow(@PathVariable Long userId,
+    @DeleteMapping("/{teamId}")
+    public ResponseEntity<Void> unfollow(@AuthenticationPrincipal AuthenticatedUser actor,
                                          @PathVariable Long teamId) {
-        favorites.unfollow(userId, teamId);
+        favorites.unfollow(actor.getId(), teamId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/is/hi/basketmob/controller/NotificationController.java
+++ b/src/main/java/is/hi/basketmob/controller/NotificationController.java
@@ -1,0 +1,44 @@
+package is.hi.basketmob.controller;
+
+import is.hi.basketmob.dto.NotificationDto;
+import is.hi.basketmob.security.AuthenticatedUser;
+import is.hi.basketmob.service.NotificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/me/notifications")
+public class NotificationController {
+
+    private final NotificationService notifications;
+
+    public NotificationController(NotificationService notifications) {
+        this.notifications = notifications;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<NotificationDto>> list(@AuthenticationPrincipal AuthenticatedUser actor) {
+        return ResponseEntity.ok(notifications.list(actor.getId()));
+    }
+
+    @PostMapping("/{id}/read")
+    public ResponseEntity<Void> markRead(@AuthenticationPrincipal AuthenticatedUser actor,
+                                         @PathVariable Long id) {
+        notifications.markRead(actor.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> clear(@AuthenticationPrincipal AuthenticatedUser actor) {
+        notifications.clear(actor.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/is/hi/basketmob/dto/GameUpdateRequest.java
+++ b/src/main/java/is/hi/basketmob/dto/GameUpdateRequest.java
@@ -1,0 +1,42 @@
+package is.hi.basketmob.dto;
+
+import is.hi.basketmob.entity.Game;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class GameUpdateRequest {
+
+    @NotNull
+    private Game.Status status;
+
+    @Min(0)
+    private Integer homeScore;
+
+    @Min(0)
+    private Integer awayScore;
+
+    public Game.Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Game.Status status) {
+        this.status = status;
+    }
+
+    public Integer getHomeScore() {
+        return homeScore;
+    }
+
+    public void setHomeScore(Integer homeScore) {
+        this.homeScore = homeScore;
+    }
+
+    public Integer getAwayScore() {
+        return awayScore;
+    }
+
+    public void setAwayScore(Integer awayScore) {
+        this.awayScore = awayScore;
+    }
+}

--- a/src/main/java/is/hi/basketmob/dto/NotificationDto.java
+++ b/src/main/java/is/hi/basketmob/dto/NotificationDto.java
@@ -1,0 +1,11 @@
+package is.hi.basketmob.dto;
+
+import java.time.OffsetDateTime;
+
+public record NotificationDto(
+        Long id,
+        Long gameId,
+        String message,
+        boolean read,
+        OffsetDateTime createdAt
+) {}

--- a/src/main/java/is/hi/basketmob/entity/Notification.java
+++ b/src/main/java/is/hi/basketmob/entity/Notification.java
@@ -1,0 +1,81 @@
+package is.hi.basketmob.entity;
+
+import javax.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Game game;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(nullable = false)
+    private boolean readFlag = false;
+
+    @Column(nullable = false, columnDefinition = "timestamp")
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    public Notification() {
+    }
+
+    public Notification(User user, Game game, String message) {
+        this.user = user;
+        this.game = game;
+        this.message = message;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Game getGame() {
+        return game;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isReadFlag() {
+        return readFlag;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public void setGame(Game game) {
+        this.game = game;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public void setReadFlag(boolean readFlag) {
+        this.readFlag = readFlag;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/is/hi/basketmob/notification/GameUpdateObserver.java
+++ b/src/main/java/is/hi/basketmob/notification/GameUpdateObserver.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.notification;
+
+import is.hi.basketmob.entity.Game;
+
+public interface GameUpdateObserver {
+    void onGameFinal(Game game);
+}

--- a/src/main/java/is/hi/basketmob/notification/GameUpdatePublisher.java
+++ b/src/main/java/is/hi/basketmob/notification/GameUpdatePublisher.java
@@ -1,0 +1,21 @@
+package is.hi.basketmob.notification;
+
+import is.hi.basketmob.entity.Game;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+public class GameUpdatePublisher {
+
+    private final List<GameUpdateObserver> observers = new CopyOnWriteArrayList<>();
+
+    public void register(GameUpdateObserver observer) {
+        observers.add(observer);
+    }
+
+    public void notifyFinal(Game game) {
+        observers.forEach(observer -> observer.onGameFinal(game));
+    }
+}

--- a/src/main/java/is/hi/basketmob/repository/NotificationRepository.java
+++ b/src/main/java/is/hi/basketmob/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package is.hi.basketmob.repository;
+
+import is.hi.basketmob.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+    Optional<Notification> findByIdAndUserId(Long id, Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/is/hi/basketmob/seed/GameSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/GameSeed.java
@@ -1,0 +1,58 @@
+package is.hi.basketmob.seed;
+
+public class GameSeed {
+    private String home;
+    private String away;
+    private String tipoff;
+    private String status;
+    private Integer homeScore;
+    private Integer awayScore;
+
+    public String getHome() {
+        return home;
+    }
+
+    public void setHome(String home) {
+        this.home = home;
+    }
+
+    public String getAway() {
+        return away;
+    }
+
+    public void setAway(String away) {
+        this.away = away;
+    }
+
+    public String getTipoff() {
+        return tipoff;
+    }
+
+    public void setTipoff(String tipoff) {
+        this.tipoff = tipoff;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getHomeScore() {
+        return homeScore;
+    }
+
+    public void setHomeScore(Integer homeScore) {
+        this.homeScore = homeScore;
+    }
+
+    public Integer getAwayScore() {
+        return awayScore;
+    }
+
+    public void setAwayScore(Integer awayScore) {
+        this.awayScore = awayScore;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueDataClient.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueDataClient.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public interface LeagueDataClient {
+    List<LeagueSeed> loadLeagues();
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueSeed.java
@@ -1,0 +1,42 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public class LeagueSeed {
+    private String name;
+    private String season;
+    private List<TeamSeed> teams;
+    private List<GameSeed> games;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSeason() {
+        return season;
+    }
+
+    public void setSeason(String season) {
+        this.season = season;
+    }
+
+    public List<TeamSeed> getTeams() {
+        return teams;
+    }
+
+    public void setTeams(List<TeamSeed> teams) {
+        this.teams = teams;
+    }
+
+    public List<GameSeed> getGames() {
+        return games;
+    }
+
+    public void setGames(List<GameSeed> games) {
+        this.games = games;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueSeedData.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueSeedData.java
@@ -1,0 +1,15 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public class LeagueSeedData {
+    private List<LeagueSeed> leagues;
+
+    public List<LeagueSeed> getLeagues() {
+        return leagues;
+    }
+
+    public void setLeagues(List<LeagueSeed> leagues) {
+        this.leagues = leagues;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LocalJsonLeagueDataClient.java
+++ b/src/main/java/is/hi/basketmob/seed/LocalJsonLeagueDataClient.java
@@ -1,0 +1,30 @@
+package is.hi.basketmob.seed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class LocalJsonLeagueDataClient implements LeagueDataClient {
+
+    private final ObjectMapper objectMapper;
+
+    public LocalJsonLeagueDataClient(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<LeagueSeed> loadLeagues() {
+        try (InputStream is = new ClassPathResource("data/dominos-2025.json").getInputStream()) {
+            LeagueSeedData data = objectMapper.readValue(is, LeagueSeedData.class);
+            return data.getLeagues() == null ? Collections.emptyList() : data.getLeagues();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load league seed data", e);
+        }
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/TeamSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/TeamSeed.java
@@ -1,0 +1,40 @@
+package is.hi.basketmob.seed;
+
+public class TeamSeed {
+    private String name;
+    private String shortName;
+    private String city;
+    private String logo;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getLogo() {
+        return logo;
+    }
+
+    public void setLogo(String logo) {
+        this.logo = logo;
+    }
+}

--- a/src/main/java/is/hi/basketmob/service/CachingStandingsProxy.java
+++ b/src/main/java/is/hi/basketmob/service/CachingStandingsProxy.java
@@ -1,0 +1,48 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.StandingDto;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Proxy that caches standings results to avoid recomputing expensive aggregates.
+ */
+@Service
+@Primary
+public class CachingStandingsProxy implements StandingsProvider {
+
+    private static final Duration TTL = Duration.ofMinutes(5);
+
+    private final StandingsProvider delegate;
+    private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    public CachingStandingsProxy(LeagueService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<StandingDto> getStandings(Long leagueId, String season) {
+        String key = cacheKey(leagueId, season);
+        CacheEntry entry = cache.get(key);
+        Instant now = Instant.now();
+        if (entry != null && entry.expiresAt.isAfter(now)) {
+            return entry.value;
+        }
+        List<StandingDto> result = delegate.getStandings(leagueId, season);
+        List<StandingDto> snapshot = List.copyOf(result);
+        cache.put(key, new CacheEntry(snapshot, now.plus(TTL)));
+        return snapshot;
+    }
+
+    private String cacheKey(Long leagueId, String season) {
+        return leagueId + ":" + (season == null ? "" : season);
+    }
+
+    private record CacheEntry(List<StandingDto> value, Instant expiresAt) {}
+}

--- a/src/main/java/is/hi/basketmob/service/FavoriteService.java
+++ b/src/main/java/is/hi/basketmob/service/FavoriteService.java
@@ -38,7 +38,7 @@ public class FavoriteService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ALREADY_FAVORITED");
         }
         favorites.save(new Favorite(u, t));
-        return new TeamDto(t.getId(), t.getName());
+        return toDto(t);
     }
 
     @Transactional
@@ -55,7 +55,17 @@ public class FavoriteService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
 
         return favorites.findByUserId(userId).stream()
-                .map(f -> new TeamDto(f.getTeam().getId(), f.getTeam().getName()))
+                .map(f -> toDto(f.getTeam()))
                 .collect(Collectors.toList());
+    }
+
+    private TeamDto toDto(Team team) {
+        return new TeamDto(
+                team.getId(),
+                team.getName(),
+                team.getShortName(),
+                team.getCity(),
+                team.getLogoUrl()
+        );
     }
 }

--- a/src/main/java/is/hi/basketmob/service/GameCommandService.java
+++ b/src/main/java/is/hi/basketmob/service/GameCommandService.java
@@ -1,0 +1,86 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.GameDto;
+import is.hi.basketmob.dto.GameUpdateRequest;
+import is.hi.basketmob.dto.TeamDto;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.notification.GameUpdatePublisher;
+import is.hi.basketmob.repository.GameRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@Profile("!stub")
+public class GameCommandService {
+
+    private final GameRepository games;
+    private final GameUpdatePublisher publisher;
+
+    public GameCommandService(GameRepository games, GameUpdatePublisher publisher) {
+        this.games = games;
+        this.publisher = publisher;
+    }
+
+    @Transactional
+    public GameDto updateGame(Long id, GameUpdateRequest request) {
+        Game game = games.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "GAME_NOT_FOUND"));
+
+        if (request.getStatus() == Game.Status.FINAL &&
+                (request.getHomeScore() == null || request.getAwayScore() == null)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Scores required when marking game as FINAL");
+        }
+
+        if (request.getHomeScore() != null) {
+            game.setHomeScore(request.getHomeScore());
+        }
+        if (request.getAwayScore() != null) {
+            game.setAwayScore(request.getAwayScore());
+        }
+        if (request.getStatus() != null) {
+            game.setStatus(request.getStatus());
+        }
+
+        Game saved = games.save(game);
+
+        if (saved.getStatus() == Game.Status.FINAL) {
+            publisher.notifyFinal(saved);
+        }
+
+        return toDto(saved);
+    }
+
+    private GameDto toDto(Game g) {
+        TeamDto homeDto = toTeamDto(g.getHomeTeam());
+        TeamDto awayDto = toTeamDto(g.getAwayTeam());
+
+        var tip = g.getTipoff();
+        String date = tip.toLocalDate().toString();
+        String time = tip.toLocalTime()
+                .truncatedTo(ChronoUnit.MINUTES)
+                .format(DateTimeFormatter.ofPattern("HH:mm"));
+
+        return new GameDto(
+                g.getId(), date, time,
+                homeDto, awayDto,
+                g.getHomeScore(), g.getAwayScore()
+        );
+    }
+
+    private TeamDto toTeamDto(Team team) {
+        return new TeamDto(
+                team.getId(),
+                team.getName(),
+                team.getShortName(),
+                team.getCity(),
+                team.getLogoUrl()
+        );
+    }
+}

--- a/src/main/java/is/hi/basketmob/service/NotificationService.java
+++ b/src/main/java/is/hi/basketmob/service/NotificationService.java
@@ -1,0 +1,100 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.NotificationDto;
+import is.hi.basketmob.entity.Favorite;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.Notification;
+import is.hi.basketmob.notification.GameUpdateObserver;
+import is.hi.basketmob.notification.GameUpdatePublisher;
+import is.hi.basketmob.repository.FavoriteRepository;
+import is.hi.basketmob.repository.NotificationRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class NotificationService implements GameUpdateObserver {
+
+    private final NotificationRepository notifications;
+    private final FavoriteRepository favorites;
+
+    public NotificationService(NotificationRepository notifications,
+                               FavoriteRepository favorites,
+                               GameUpdatePublisher publisher) {
+        this.notifications = notifications;
+        this.favorites = favorites;
+        publisher.register(this);
+    }
+
+    @Override
+    @Transactional
+    public void onGameFinal(Game game) {
+        List<Long> teamIds = List.of(
+                game.getHomeTeam().getId(),
+                game.getAwayTeam().getId()
+        );
+        List<Favorite> followers = favorites.findByTeamIdIn(teamIds);
+        if (followers.isEmpty()) {
+            return;
+        }
+
+        String message = formatMessage(game);
+        Set<Long> notifiedUsers = new HashSet<>();
+        for (Favorite favorite : followers) {
+            Long userId = favorite.getUser().getId();
+            if (notifiedUsers.add(userId)) {
+                Notification notification = new Notification(favorite.getUser(), game, message);
+                notifications.save(notification);
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationDto> list(Long userId) {
+        return notifications.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void markRead(Long userId, Long notificationId) {
+        Notification notification = notifications.findByIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND"));
+        notification.setReadFlag(true);
+        notifications.save(notification);
+    }
+
+    @Transactional
+    public void clear(Long userId) {
+        notifications.deleteByUserId(userId);
+    }
+
+    private NotificationDto toDto(Notification notification) {
+        return new NotificationDto(
+                notification.getId(),
+                notification.getGame().getId(),
+                notification.getMessage(),
+                notification.isReadFlag(),
+                notification.getCreatedAt()
+        );
+    }
+
+    private String formatMessage(Game game) {
+        Integer homeScore = game.getHomeScore() == null ? 0 : game.getHomeScore();
+        Integer awayScore = game.getAwayScore() == null ? 0 : game.getAwayScore();
+        return String.format(
+                "%s %d - %d %s",
+                game.getHomeTeam().getName(),
+                homeScore,
+                awayScore,
+                game.getAwayTeam().getName()
+        );
+    }
+}

--- a/src/main/java/is/hi/basketmob/service/StandingsProvider.java
+++ b/src/main/java/is/hi/basketmob/service/StandingsProvider.java
@@ -1,0 +1,9 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.StandingDto;
+
+import java.util.List;
+
+public interface StandingsProvider {
+    List<StandingDto> getStandings(Long leagueId, String season);
+}

--- a/src/test/java/is/hi/basketmob/service/LeagueServiceTest.java
+++ b/src/test/java/is/hi/basketmob/service/LeagueServiceTest.java
@@ -1,0 +1,107 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.StandingDto;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.repository.GameRepository;
+import is.hi.basketmob.repository.LeagueRepository;
+import is.hi.basketmob.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeagueServiceTest {
+
+    @Mock
+    private LeagueRepository leagueRepository;
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private GameRepository gameRepository;
+
+    private LeagueService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeagueService(leagueRepository, teamRepository, gameRepository);
+    }
+
+    @Test
+    void calculatesStandingsWithExtendedStats() {
+        League league = new League();
+        league.setSeason("2025");
+        ReflectionTestUtils.setField(league, "id", 1L);
+
+        Team valur = new Team();
+        valur.setName("Valur");
+        ReflectionTestUtils.setField(valur, "id", 100L);
+
+        Team kr = new Team();
+        kr.setName("KR");
+        ReflectionTestUtils.setField(kr, "id", 200L);
+
+        when(leagueRepository.findById(1L)).thenReturn(Optional.of(league));
+        when(teamRepository.findByLeagueId(1L)).thenReturn(List.of(valur, kr));
+
+        Game g1 = finalGame(league, valur, kr, 88, 80);
+        Game g2 = finalGame(league, kr, valur, 70, 85);
+        when(gameRepository.findByLeagueIdAndStatus(1L, Game.Status.FINAL)).thenReturn(List.of(g1, g2));
+
+        List<StandingDto> standings = service.getStandings(1L, "2025");
+
+        assertThat(standings).hasSize(2);
+        StandingDto leader = standings.get(0);
+        assertThat(leader.teamName()).isEqualTo("Valur");
+        assertThat(leader.wins()).isEqualTo(2);
+        assertThat(leader.losses()).isZero();
+        assertThat(leader.gamesPlayed()).isEqualTo(2);
+        assertThat(leader.pointsFor()).isEqualTo(173);
+        assertThat(leader.pointsAgainst()).isEqualTo(150);
+        assertThat(leader.winPct()).isEqualTo(1.0d);
+
+        StandingDto runnerUp = standings.get(1);
+        assertThat(runnerUp.teamName()).isEqualTo("KR");
+        assertThat(runnerUp.wins()).isZero();
+        assertThat(runnerUp.losses()).isEqualTo(2);
+        assertThat(runnerUp.pointsFor()).isEqualTo(150);
+    }
+
+    @Test
+    void rejectsSeasonMismatch() {
+        League league = new League();
+        league.setSeason("2025");
+        ReflectionTestUtils.setField(league, "id", 1L);
+        when(leagueRepository.findById(1L)).thenReturn(Optional.of(league));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.getStandings(1L, "2024"));
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private Game finalGame(League league, Team home, Team away, int homeScore, int awayScore) {
+        Game game = new Game();
+        game.setLeague(league);
+        game.setHomeTeam(home);
+        game.setAwayTeam(away);
+        game.setTipoff(LocalDateTime.now());
+        game.setStatus(Game.Status.FINAL);
+        game.setHomeScore(homeScore);
+        game.setAwayScore(awayScore);
+        return game;
+    }
+}

--- a/src/test/java/is/hi/basketmob/service/NotificationServiceTest.java
+++ b/src/test/java/is/hi/basketmob/service/NotificationServiceTest.java
@@ -1,0 +1,86 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.entity.Favorite;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Notification;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.entity.User;
+import is.hi.basketmob.notification.GameUpdatePublisher;
+import is.hi.basketmob.repository.FavoriteRepository;
+import is.hi.basketmob.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    private NotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationService(notificationRepository, favoriteRepository, new GameUpdatePublisher());
+    }
+
+    @Test
+    void createsNotificationForFollowersWhenGameEnds() {
+        Team valur = team(10L, "Valur");
+        Team kr = team(20L, "KR");
+        Game finalGame = new Game();
+        finalGame.setLeague(new League());
+        finalGame.setHomeTeam(valur);
+        finalGame.setAwayTeam(kr);
+        finalGame.setTipoff(LocalDateTime.now());
+        finalGame.setStatus(Game.Status.FINAL);
+        finalGame.setHomeScore(90);
+        finalGame.setAwayScore(82);
+
+        Favorite adminFavorite = new Favorite(user(1L, "admin@basketmob.is"), valur);
+        Favorite tomasFavorite = new Favorite(user(2L, "tomas@example.com"), kr);
+        when(favoriteRepository.findByTeamIdIn(anyList())).thenReturn(List.of(adminFavorite, tomasFavorite));
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.onGameFinal(finalGame);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, times(2)).save(captor.capture());
+        List<Notification> saved = captor.getAllValues();
+        assertThat(saved).hasSize(2);
+        assertThat(saved.get(0).getMessage()).contains("Valur");
+        assertThat(saved.get(0).isReadFlag()).isFalse();
+    }
+
+    private Team team(Long id, String name) {
+        Team team = new Team();
+        team.setName(name);
+        ReflectionTestUtils.setField(team, "id", id);
+        return team;
+    }
+
+    private User user(Long id, String email) {
+        User user = new User();
+        user.setEmail(email);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
feat: admin game finalization + follower notifications

> Pair-programming note: Work co-created by @alexa + @tomasandri99 while pairing locally (Nov 8–9). Tomas designed the observer + tests; I pushed the commit.

## Summary
- Added AdminGameController + GameCommandService so admins can finalize/update games.
- Introduced Notification DTO/entity/repository/service plus a /api/v1/notifications endpoint.
- FavoriteService now publishes notifications when followed teams finish a game.

## Verification
1. ./mvnw clean test
2. ./mvnw spring-boot:run
3. Login as admin, call POST /api/v1/admin/games/{id}/finalize, then GET /api/v1/notifications?userId=… to see follower alerts.

## Remaining gaps / next steps
- Wire NotificationService into a scheduled cleanup + UI surface.
- Secure favorites endpoints (enforce actor == userId) so notifications can trust ownership.
- Rate limiting + caching still pending for A4.