### PR TITLE
feat(ui): Thymeleaf home/games/standings/dashboard

### DIFF
--- a/src/main/java/is/hi/basketmob/controller/UiAccountController.java
+++ b/src/main/java/is/hi/basketmob/controller/UiAccountController.java
@@ -1,0 +1,102 @@
+package is.hi.basketmob.controller;
+
+import is.hi.basketmob.dto.UserUpdateRequest;
+import is.hi.basketmob.security.AuthenticatedUser;
+import is.hi.basketmob.service.FavoriteService;
+import is.hi.basketmob.service.NotificationService;
+import is.hi.basketmob.service.UserService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.validation.Valid;
+@Controller
+@RequestMapping("/dashboard")
+public class UiAccountController {
+
+    private final UserService userService;
+    private final FavoriteService favoriteService;
+    private final NotificationService notificationService;
+
+    public UiAccountController(UserService userService,
+                               FavoriteService favoriteService,
+                               NotificationService notificationService) {
+        this.userService = userService;
+        this.favoriteService = favoriteService;
+        this.notificationService = notificationService;
+    }
+
+    @PostMapping("/profile")
+    public String updateProfile(@AuthenticationPrincipal AuthenticatedUser actor,
+                                @Valid @ModelAttribute("profileForm") UserUpdateRequest form,
+                                BindingResult result,
+                                RedirectAttributes redirectAttributes) {
+        if (actor == null) {
+            return "redirect:/login";
+        }
+        if (result.hasErrors()) {
+            redirectAttributes.addFlashAttribute("profileForm", form);
+            redirectAttributes.addFlashAttribute("error", "Inntak þarf að vera gilt áður en hægt er að vista prófíl.");
+            return "redirect:/dashboard";
+        }
+        try {
+            userService.updateUser(actor.getId(), form, actor.getId(), actor.isAdmin(), false);
+            redirectAttributes.addFlashAttribute("toast", "Prófíl uppfærður.");
+        } catch (ResponseStatusException ex) {
+            redirectAttributes.addFlashAttribute("profileForm", form);
+            redirectAttributes.addFlashAttribute("error", ex.getReason());
+        }
+        return "redirect:/dashboard";
+    }
+
+    @PostMapping("/favorites")
+    public String followTeam(@AuthenticationPrincipal AuthenticatedUser actor,
+                             @RequestParam Long teamId,
+                             RedirectAttributes redirectAttributes) {
+        if (actor == null) {
+            return "redirect:/login";
+        }
+        try {
+            favoriteService.follow(actor.getId(), teamId);
+            redirectAttributes.addFlashAttribute("toast", "Lið bætt við uppáhaldslista.");
+        } catch (ResponseStatusException ex) {
+            redirectAttributes.addFlashAttribute("error", ex.getReason());
+        }
+        return "redirect:/dashboard";
+    }
+
+    @PostMapping("/favorites/{teamId}/delete")
+    public String unfollow(@AuthenticationPrincipal AuthenticatedUser actor,
+                           @PathVariable Long teamId,
+                           RedirectAttributes redirectAttributes) {
+        if (actor == null) {
+            return "redirect:/login";
+        }
+        try {
+            favoriteService.unfollow(actor.getId(), teamId);
+            redirectAttributes.addFlashAttribute("toast", "Lið fjarlægt af uppáhaldslista.");
+        } catch (ResponseStatusException ex) {
+            redirectAttributes.addFlashAttribute("error", ex.getReason());
+        }
+        return "redirect:/dashboard";
+    }
+
+    @PostMapping("/notifications/clear")
+    public String clearNotifications(@AuthenticationPrincipal AuthenticatedUser actor,
+                                     RedirectAttributes redirectAttributes) {
+        if (actor == null) {
+            return "redirect:/login";
+        }
+        notificationService.clear(actor.getId());
+        redirectAttributes.addFlashAttribute("toast", "Tilkynningar hreinsaðar.");
+        return "redirect:/dashboard";
+    }
+
+}

--- a/src/main/java/is/hi/basketmob/controller/ViewController.java
+++ b/src/main/java/is/hi/basketmob/controller/ViewController.java
@@ -1,0 +1,145 @@
+package is.hi.basketmob.controller;
+
+import is.hi.basketmob.dto.GameListItemDto;
+import is.hi.basketmob.dto.NotificationDto;
+import is.hi.basketmob.dto.StandingDto;
+import is.hi.basketmob.dto.TeamDto;
+import is.hi.basketmob.dto.UserUpdateRequest;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.repository.LeagueRepository;
+import is.hi.basketmob.repository.TeamRepository;
+import is.hi.basketmob.security.AuthenticatedUser;
+import is.hi.basketmob.service.FavoriteService;
+import is.hi.basketmob.service.GameService;
+import is.hi.basketmob.service.NotificationService;
+import is.hi.basketmob.service.StandingsProvider;
+import is.hi.basketmob.service.UserService;
+import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Controller
+public class ViewController {
+
+    private final GameService gameService;
+    private final StandingsProvider standingsProvider;
+    private final LeagueRepository leagues;
+    private final FavoriteService favoriteService;
+    private final NotificationService notificationService;
+    private final UserService userService;
+    private final TeamRepository teamRepository;
+
+    public ViewController(GameService gameService,
+                          StandingsProvider standingsProvider,
+                          LeagueRepository leagues,
+                          FavoriteService favoriteService,
+                          NotificationService notificationService,
+                          UserService userService,
+                          TeamRepository teamRepository) {
+        this.gameService = gameService;
+        this.standingsProvider = standingsProvider;
+        this.leagues = leagues;
+        this.favoriteService = favoriteService;
+        this.notificationService = notificationService;
+        this.userService = userService;
+        this.teamRepository = teamRepository;
+    }
+
+    @GetMapping("/")
+    public String home(Model model) {
+        LocalDate today = LocalDate.now();
+        List<League> allLeagues = leagues.findAll();
+        League featured = selectLeague(null, allLeagues);
+        List<GameListItemDto> gamesToday = gameService.listByDate(today, 0, 5, "tipoff,asc").getContent();
+        model.addAttribute("today", today);
+        model.addAttribute("games", gamesToday);
+        model.addAttribute("leagues", allLeagues);
+        model.addAttribute("featuredLeague", featured);
+        model.addAttribute("featuredStandings", featured == null
+                ? Collections.emptyList()
+                : standingsProvider.getStandings(featured.getId(), featured.getSeason()));
+        return "index";
+    }
+
+    @GetMapping("/games")
+    public String games(@RequestParam(required = false)
+                        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                        LocalDate date,
+                        Model model) {
+        LocalDate target = date != null ? date : LocalDate.now();
+        model.addAttribute("selectedDate", target);
+        model.addAttribute("games",
+                gameService.listByDate(target, 0, 50, "tipoff,asc").getContent());
+        return "games";
+    }
+
+    @GetMapping("/standings")
+    public String standings(@RequestParam(required = false) Long leagueId,
+                            Model model) {
+        List<League> allLeagues = leagues.findAll();
+        model.addAttribute("leagues", allLeagues);
+
+        League selected = selectLeague(leagueId, allLeagues);
+        List<StandingDto> rows = selected == null
+                ? Collections.emptyList()
+                : standingsProvider.getStandings(selected.getId(), selected.getSeason());
+
+        model.addAttribute("selectedLeague", selected);
+        model.addAttribute("standings", rows);
+        return "standings";
+    }
+
+    @GetMapping("/dashboard")
+    public String dashboard(@AuthenticationPrincipal AuthenticatedUser actor, Model model) {
+        if (actor == null) {
+            return "redirect:/login";
+        }
+
+        var user = userService.findById(actor.getId());
+        List<TeamDto> favorites = favoriteService.list(actor.getId());
+        List<NotificationDto> notifications = notificationService.list(actor.getId());
+        List<Team> allTeams = teamRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
+        Set<Long> favoriteIds = favorites.stream().map(TeamDto::id).collect(Collectors.toSet());
+        List<Team> availableTeams = allTeams.stream()
+                .filter(team -> !favoriteIds.contains(team.getId()))
+                .collect(Collectors.toList());
+
+        UserUpdateRequest profileForm = new UserUpdateRequest();
+        profileForm.setDisplayName(user.getDisplayName());
+        profileForm.setAvatarUrl(user.getAvatarUrl());
+        profileForm.setGender(user.getGender());
+
+        model.addAttribute("profile", user);
+        model.addAttribute("favorites", favorites);
+        model.addAttribute("notifications", notifications);
+        model.addAttribute("availableTeams", availableTeams);
+        if (!model.containsAttribute("profileForm")) {
+            model.addAttribute("profileForm", profileForm);
+        }
+        return "dashboard";
+    }
+
+    private League selectLeague(Long leagueId, List<League> all) {
+        if (all.isEmpty()) {
+            return null;
+        }
+        if (leagueId == null) {
+            return all.get(0);
+        }
+        return all.stream()
+                .filter(l -> l.getId().equals(leagueId))
+                .findFirst()
+                .orElse(all.get(0));
+    }
+}

--- a/src/main/java/is/hi/basketmob/notification/GameUpdateObserver.java
+++ b/src/main/java/is/hi/basketmob/notification/GameUpdateObserver.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.notification;
+
+import is.hi.basketmob.entity.Game;
+
+public interface GameUpdateObserver {
+    void onGameFinal(Game game);
+}

--- a/src/main/java/is/hi/basketmob/notification/GameUpdatePublisher.java
+++ b/src/main/java/is/hi/basketmob/notification/GameUpdatePublisher.java
@@ -1,0 +1,21 @@
+package is.hi.basketmob.notification;
+
+import is.hi.basketmob.entity.Game;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+public class GameUpdatePublisher {
+
+    private final List<GameUpdateObserver> observers = new CopyOnWriteArrayList<>();
+
+    public void register(GameUpdateObserver observer) {
+        observers.add(observer);
+    }
+
+    public void notifyFinal(Game game) {
+        observers.forEach(observer -> observer.onGameFinal(game));
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/GameSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/GameSeed.java
@@ -1,0 +1,58 @@
+package is.hi.basketmob.seed;
+
+public class GameSeed {
+    private String home;
+    private String away;
+    private String tipoff;
+    private String status;
+    private Integer homeScore;
+    private Integer awayScore;
+
+    public String getHome() {
+        return home;
+    }
+
+    public void setHome(String home) {
+        this.home = home;
+    }
+
+    public String getAway() {
+        return away;
+    }
+
+    public void setAway(String away) {
+        this.away = away;
+    }
+
+    public String getTipoff() {
+        return tipoff;
+    }
+
+    public void setTipoff(String tipoff) {
+        this.tipoff = tipoff;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getHomeScore() {
+        return homeScore;
+    }
+
+    public void setHomeScore(Integer homeScore) {
+        this.homeScore = homeScore;
+    }
+
+    public Integer getAwayScore() {
+        return awayScore;
+    }
+
+    public void setAwayScore(Integer awayScore) {
+        this.awayScore = awayScore;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueDataClient.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueDataClient.java
@@ -1,0 +1,7 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public interface LeagueDataClient {
+    List<LeagueSeed> loadLeagues();
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueSeed.java
@@ -1,0 +1,42 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public class LeagueSeed {
+    private String name;
+    private String season;
+    private List<TeamSeed> teams;
+    private List<GameSeed> games;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSeason() {
+        return season;
+    }
+
+    public void setSeason(String season) {
+        this.season = season;
+    }
+
+    public List<TeamSeed> getTeams() {
+        return teams;
+    }
+
+    public void setTeams(List<TeamSeed> teams) {
+        this.teams = teams;
+    }
+
+    public List<GameSeed> getGames() {
+        return games;
+    }
+
+    public void setGames(List<GameSeed> games) {
+        this.games = games;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LeagueSeedData.java
+++ b/src/main/java/is/hi/basketmob/seed/LeagueSeedData.java
@@ -1,0 +1,15 @@
+package is.hi.basketmob.seed;
+
+import java.util.List;
+
+public class LeagueSeedData {
+    private List<LeagueSeed> leagues;
+
+    public List<LeagueSeed> getLeagues() {
+        return leagues;
+    }
+
+    public void setLeagues(List<LeagueSeed> leagues) {
+        this.leagues = leagues;
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/LocalJsonLeagueDataClient.java
+++ b/src/main/java/is/hi/basketmob/seed/LocalJsonLeagueDataClient.java
@@ -1,0 +1,30 @@
+package is.hi.basketmob.seed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class LocalJsonLeagueDataClient implements LeagueDataClient {
+
+    private final ObjectMapper objectMapper;
+
+    public LocalJsonLeagueDataClient(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<LeagueSeed> loadLeagues() {
+        try (InputStream is = new ClassPathResource("data/dominos-2025.json").getInputStream()) {
+            LeagueSeedData data = objectMapper.readValue(is, LeagueSeedData.class);
+            return data.getLeagues() == null ? Collections.emptyList() : data.getLeagues();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load league seed data", e);
+        }
+    }
+}

--- a/src/main/java/is/hi/basketmob/seed/TeamSeed.java
+++ b/src/main/java/is/hi/basketmob/seed/TeamSeed.java
@@ -1,0 +1,40 @@
+package is.hi.basketmob.seed;
+
+public class TeamSeed {
+    private String name;
+    private String shortName;
+    private String city;
+    private String logo;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getLogo() {
+        return logo;
+    }
+
+    public void setLogo(String logo) {
+        this.logo = logo;
+    }
+}

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -1,0 +1,294 @@
+:root {
+    font-family: "Segoe UI", Arial, sans-serif;
+    color: #0b0b0f;
+    background-color: #f5f6f8;
+}
+
+body {
+    margin: 0;
+    background-color: #f5f6f8;
+    color: #0b0b0f;
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.site-header {
+    background: #0b0b0f;
+    color: #fff;
+    padding: 1rem 0;
+}
+
+.nav-grid {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 1rem;
+}
+
+.logo {
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+nav a {
+    color: #cdd3ff;
+    margin-right: 1rem;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+nav a:hover {
+    color: #fff;
+}
+
+.auth-controls {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.hero {
+    background: #ffffff;
+    padding: 2rem;
+    border-radius: 12px;
+    margin: 2rem 0;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.07);
+}
+
+.hero-actions {
+    margin-top: 1.5rem;
+}
+
+.btn {
+    display: inline-block;
+    padding: 0.6rem 1.4rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+}
+
+.btn.primary {
+    background: #4f46e5;
+    color: #fff;
+}
+
+.btn.secondary {
+    background: #fff;
+    color: #4f46e5;
+    border: 1px solid #4f46e5;
+}
+
+.btn.tertiary {
+    background: #fde68a;
+    color: #92400e;
+}
+
+.btn.full {
+    width: 100%;
+    text-align: center;
+}
+
+.link-btn {
+    background: transparent;
+    border: none;
+    color: #4f46e5;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.9rem;
+}
+
+.muted {
+    color: #6b7280;
+    font-size: 0.9rem;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+}
+
+.game-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+}
+
+.game-card .game-time {
+    font-weight: 600;
+}
+
+.game-card .status {
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.game-teams {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.filter-bar {
+    margin: 2rem 0 1rem;
+}
+
+.filter-form {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.standings-table-wrapper {
+    overflow-x: auto;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+}
+
+thead {
+    background: #f3f4f6;
+}
+
+.form-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.05);
+    margin-bottom: 1.5rem;
+}
+
+.form-card form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="url"],
+input[type="date"],
+select {
+    padding: 0.65rem;
+    border-radius: 8px;
+    border: 1px solid #d1d5db;
+    font-size: 1rem;
+}
+
+.field-error {
+    color: #b91c1c;
+    font-size: 0.85rem;
+}
+
+.flash-container {
+    max-width: 960px;
+    margin: 1rem auto;
+    padding: 0 1.5rem;
+}
+
+.flash {
+    padding: 0.9rem 1.2rem;
+    border-radius: 10px;
+    margin-bottom: 0.75rem;
+    font-weight: 500;
+}
+
+.flash-success {
+    background: #ecfdf5;
+    color: #065f46;
+}
+
+.flash-error {
+    background: #fef2f2;
+    color: #b91c1c;
+}
+
+.container.narrow {
+    max-width: 520px;
+}
+
+.user-card {
+    background: #111827;
+    color: #fff;
+    padding: 1.5rem;
+    border-radius: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 2rem 0 1rem;
+}
+
+.badge {
+    background: rgba(255, 255, 255, 0.15);
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.favorite-list,
+.notification-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem 0;
+}
+
+.favorite-list li,
+.notification-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.site-footer {
+    margin-top: 3rem;
+    padding: 2rem 0;
+    background: #0b0b0f;
+    color: #fff;
+    text-align: center;
+}
+
+.user-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.chip-label {
+    font-size: 0.9rem;
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>BasketMob · Mín síða</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+</head>
+<body>
+<header th:replace="fragments/nav :: siteNav"></header>
+<div th:replace="fragments/nav :: alerts"></div>
+
+<main class="container">
+    <section class="user-card">
+        <div>
+            <h1 th:text="${profile.displayName != null ? profile.displayName : profile.email}"></h1>
+            <p class="muted" th:text="${profile.email}"></p>
+        </div>
+        <div class="badge" th:text="${profile.admin} ? 'Stjórnandi' : 'Aðgangur'"></div>
+    </section>
+
+    <section class="dashboard-grid">
+        <article class="form-card">
+            <h2>Uppfæra prófíl</h2>
+            <form method="post" th:action="@{/dashboard/profile}" th:object="${profileForm}">
+                <label for="displayName">Sýnilegt nafn</label>
+                <input type="text" id="displayName" th:field="*{displayName}">
+                <div class="field-error" th:if="${#fields.hasErrors('displayName')}" th:errors="*{displayName}"></div>
+
+                <label for="avatarUrl">Mynd (slóð)</label>
+                <input type="url" id="avatarUrl" th:field="*{avatarUrl}">
+                <div class="field-error" th:if="${#fields.hasErrors('avatarUrl')}" th:errors="*{avatarUrl}"></div>
+
+                <label for="gender">Kyn</label>
+                <select id="gender" th:field="*{gender}">
+                    <option value="">Velja...</option>
+                    <option value="male">Karl</option>
+                    <option value="female">Kona</option>
+                    <option value="other">Annað</option>
+                </select>
+                <div class="field-error" th:if="${#fields.hasErrors('gender')}" th:errors="*{gender}"></div>
+
+                <button type="submit" class="btn primary full">Vista breytingar</button>
+            </form>
+        </article>
+
+        <article class="form-card">
+            <h2>Uppáhaldslið</h2>
+            <p th:if="${favorites.isEmpty()}" class="muted">Þú hefur ekki valið lið ennþá.</p>
+            <ul class="favorite-list" th:if="${!favorites.isEmpty()}">
+                <li th:each="team : ${favorites}">
+                    <span>
+                        <strong th:text="${team.name()}"></strong>
+                        <small class="muted" th:text="${team.city()}"></small>
+                    </span>
+                    <form method="post" th:action="@{'/dashboard/favorites/' + ${team.id()} + '/delete'}">
+                        <button type="submit" class="link-btn">Fjarlægja</button>
+                    </form>
+                </li>
+            </ul>
+            <hr>
+            <form method="post" th:action="@{/dashboard/favorites}">
+                <label for="teamId">Bæta við liði</label>
+                <select id="teamId" name="teamId" required>
+                    <option value="" disabled selected>Veldu lið</option>
+                    <option th:each="team : ${availableTeams}"
+                            th:value="${team.id}"
+                            th:text="${team.name} + ' (' + team.city + ')'"></option>
+                </select>
+                <button type="submit" class="btn secondary full" th:disabled="${availableTeams.isEmpty()}">Bæta við</button>
+                <p th:if="${availableTeams.isEmpty()}" class="muted">Allir liðir eru þegar á listanum.</p>
+            </form>
+        </article>
+    </section>
+
+    <section class="form-card">
+        <div class="section-header">
+            <h2>Tilkynningar</h2>
+            <form method="post" th:action="@{/dashboard/notifications/clear}">
+                <button type="submit" class="link-btn">Hreinsa</button>
+            </form>
+        </div>
+        <p th:if="${notifications.isEmpty()}" class="muted">Engar tilkynningar í bili.</p>
+        <ul class="notification-list" th:if="${!notifications.isEmpty()}">
+            <li th:each="note : ${notifications}">
+                <div>
+                    <strong th:text="${note.message()}"></strong>
+                    <small class="muted" th:text="${#temporals.format(note.createdAt(), 'dd.MM.yyyy HH:mm')}"></small>
+                </div>
+            </li>
+        </ul>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container">
+        <span>© 2025 BasketMob</span>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<header class="site-header" th:fragment="siteNav">
+    <div class="container nav-grid">
+        <a class="logo" th:href="@{/}">BasketMob</a>
+        <nav>
+            <a th:href="@{/}">Heim</a>
+            <a th:href="@{/games}">Leikir</a>
+            <a th:href="@{/standings}">Staðan</a>
+            <a th:if="${currentUser != null}" th:href="@{/dashboard}">Mín síða</a>
+        </nav>
+        <div class="auth-controls">
+            <div th:if="${currentUser == null}">
+                <a class="btn secondary" th:href="@{/login}">Innskrá</a>
+                <a class="btn primary" th:href="@{/register}">Nýskráning</a>
+            </div>
+            <div th:if="${currentUser != null}" class="user-chip">
+                <span class="chip-label" th:text="${currentUser.username}"></span>
+                <form method="post" th:action="@{/logout}">
+                    <button type="submit" class="link-btn">Útskrá</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</header>
+
+<div class="flash-container" th:fragment="alerts">
+    <div class="flash flash-success" th:if="${toast != null}" th:text="${toast}"></div>
+    <div class="flash flash-error" th:if="${error != null}" th:text="${error}"></div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/games.html
+++ b/src/main/resources/templates/games.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>BasketMob · Leikir</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+</head>
+<body>
+<header th:replace="fragments/nav :: siteNav"></header>
+<div th:replace="fragments/nav :: alerts"></div>
+
+<main class="container">
+    <section class="filter-bar">
+        <form method="get" action="#" class="filter-form">
+            <label for="date">Dagsetning</label>
+            <input type="date" id="date" name="date" th:value="${selectedDate}">
+            <button type="submit" class="btn primary">Sækja</button>
+        </form>
+    </section>
+
+    <section>
+        <h2 th:text="'Leikir ' + ${selectedDate}"></h2>
+        <p th:if="${games.isEmpty()}">Engir leikir fundust á þessari dagsetningu.</p>
+        <div class="card-grid" th:if="${!games.isEmpty()}">
+            <article class="game-card detailed" th:each="game : ${games}">
+                <header>
+                    <span class="game-time" th:text="${game.tipoff()}"></span>
+                    <span class="status badge" th:text="${game.status()}"></span>
+                </header>
+                <div class="game-teams">
+                    <strong th:text="${game.homeName()}"></strong>
+                    <span>vs</span>
+                    <strong th:text="${game.awayName()}"></strong>
+                </div>
+            </article>
+        </div>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container">
+        <span>Gögn byggja á nýjustu seed skrá.</span>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>BasketMob · Heim</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+</head>
+<body>
+<header th:replace="fragments/nav :: siteNav"></header>
+<div th:replace="fragments/nav :: alerts"></div>
+
+<main class="container">
+    <section class="hero">
+        <div>
+            <h2>Allt um íslenska körfuboltann á einum stað.</h2>
+            <p>Staðan, úrslit og dagskrá í Bónus deild karla 2025-2026.</p>
+            <div class="hero-actions">
+                <a th:href="@{/games}" class="btn primary">Skoða leiki</a>
+                <a th:href="@{/standings}" class="btn secondary">Skoða stöðuna</a>
+                <a th:if="${currentUser == null}" th:href="@{/register}" class="btn tertiary">Búa til aðgang</a>
+                <a th:if="${currentUser != null}" th:href="@{/dashboard}" class="btn tertiary">Mín síða</a>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h3 th:text="'Leikir ' + ${today}"></h3>
+        <p th:if="${games.isEmpty()}">Engir leikir á dagskrá í dag.</p>
+        <div class="card-grid" th:if="${!games.isEmpty()}">
+            <article class="game-card" th:each="game : ${games}">
+                <span class="game-time" th:text="${game.tipoff()}"></span>
+                <div class="game-teams">
+                    <span th:text="${game.homeName()}"></span>
+                    <span class="status" th:text="${game.status()}"></span>
+                    <span th:text="${game.awayName()}"></span>
+                </div>
+            </article>
+        </div>
+    </section>
+
+    <section th:if="${featuredLeague != null}">
+        <h3 th:text="${featuredLeague.name} + ' · ' + ${featuredLeague.season}"></h3>
+        <div class="standings-table-wrapper">
+            <table>
+                <thead>
+                <tr>
+                    <th>Lið</th>
+                    <th>Sig.</th>
+                    <th>Tap</th>
+                    <th>PF</th>
+                    <th>PA</th>
+                    <th>Hlutfall</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="row : ${featuredStandings}">
+                    <td th:text="${row.teamName()}"></td>
+                    <td th:text="${row.wins()}"></td>
+                    <td th:text="${row.losses()}"></td>
+                    <td th:text="${row.pointsFor()}"></td>
+                    <td th:text="${row.pointsAgainst()}"></td>
+                    <td th:text="${#numbers.formatDecimal(row.winPct()*100, 1, 1)} + '%'"></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container">
+        <span>© 2025 BasketMob</span>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>BasketMob · Innskrá</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+</head>
+<body>
+<header th:replace="fragments/nav :: siteNav"></header>
+<div th:replace="fragments/nav :: alerts"></div>
+
+<main class="container narrow">
+    <section class="form-card">
+        <h1>Innskráning</h1>
+        <form method="post" th:action="@{/login}" th:object="${loginForm}">
+            <label for="email">Netfang</label>
+            <input type="email" id="email" th:field="*{email}" placeholder="you@example.com">
+            <div class="field-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+
+            <label for="password">Lykilorð</label>
+            <input type="password" id="password" th:field="*{password}" placeholder="********">
+            <div class="field-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+
+            <div class="field-error" th:if="${#fields.hasGlobalErrors()}" th:each="err : ${#fields.globalErrors()}" th:text="${err}"></div>
+
+            <button type="submit" class="btn primary full">Innskrá</button>
+        </form>
+        <p class="muted">Enginn aðgangur? <a th:href="@{/register}">Skráðu þig hér</a>.</p>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container">
+        <span>© 2025 BasketMob</span>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>BasketMob · Nýskrá</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+</head>
+<body>
+<header th:replace="fragments/nav :: siteNav"></header>
+<div th:replace="fragments/nav :: alerts"></div>
+
+<main class="container narrow">
+    <section class="form-card">
+        <h1>Nýskráning</h1>
+        <form method="post" th:action="@{/register}" th:object="${registerForm}">
+            <label for="displayName">Nafn / sýnilegur titill</label>
+            <input type="text" id="displayName" th:field="*{displayName}" placeholder="T.d. Fan #1">
+            <div class="field-error" th:if="${#fields.hasErrors('displayName')}" th:errors="*{displayName}"></div>
+
+            <label for="email">Netfang</label>
+            <input type="email" id="email" th:field="*{email}" placeholder="you@example.com">
+            <div class="field-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+
+            <label for="password">Lykilorð</label>
+            <input type="password" id="password" th:field="*{password}" placeholder="Að minnsta kosti 8 stafir">
+            <div class="field-error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+
+            <button type="submit" class="btn primary full">Stofna aðgang</button>
+        </form>
+        <p class="muted">Kominn með aðgang? <a th:href="@{/login}">Innskráðu þig hér</a>.</p>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container">
+        <span>© 2025 BasketMob</span>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/standings.html
+++ b/src/main/resources/templates/standings.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>BasketMob · Staðan</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+</head>
+<body>
+<header th:replace="fragments/nav :: siteNav"></header>
+<div th:replace="fragments/nav :: alerts"></div>
+
+<main class="container">
+    <section class="filter-bar">
+        <form method="get" action="#" class="filter-form">
+            <label for="league">Deild</label>
+            <select id="league" name="leagueId">
+                <option th:each="league : ${leagues}"
+                        th:value="${league.id}"
+                        th:selected="${selectedLeague != null and league.id == selectedLeague.id}"
+                        th:text="${league.name} + ' ' + league.season">
+                </option>
+            </select>
+            <button type="submit" class="btn primary">Sýna</button>
+        </form>
+    </section>
+
+    <section th:if="${selectedLeague == null}">
+        <p>Engin deild hefur verið skilgreind ennþá.</p>
+    </section>
+
+    <section th:if="${selectedLeague != null}">
+        <h2 th:text="${selectedLeague.name} + ' · ' + ${selectedLeague.season}"></h2>
+        <div class="standings-table-wrapper">
+            <table>
+                <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Lið</th>
+                    <th>Sig.</th>
+                    <th>Tap</th>
+                    <th>Leikir</th>
+                    <th>PF</th>
+                    <th>PA</th>
+                    <th>Hlutfall</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="row,iter : ${standings}">
+                    <td th:text="${iter.index + 1}"></td>
+                    <td th:text="${row.teamName()}"></td>
+                    <td th:text="${row.wins()}"></td>
+                    <td th:text="${row.losses()}"></td>
+                    <td th:text="${row.gamesPlayed()}"></td>
+                    <td th:text="${row.pointsFor()}"></td>
+                    <td th:text="${row.pointsAgainst()}"></td>
+                    <td th:text="${#numbers.formatDecimal(row.winPct()*100, 1, 1)} + '%'"></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container">
+        <span>© 2025 BasketMob</span>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/test/java/is/hi/basketmob/service/LeagueServiceTest.java
+++ b/src/test/java/is/hi/basketmob/service/LeagueServiceTest.java
@@ -1,0 +1,107 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.dto.StandingDto;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.repository.GameRepository;
+import is.hi.basketmob.repository.LeagueRepository;
+import is.hi.basketmob.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeagueServiceTest {
+
+    @Mock
+    private LeagueRepository leagueRepository;
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private GameRepository gameRepository;
+
+    private LeagueService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LeagueService(leagueRepository, teamRepository, gameRepository);
+    }
+
+    @Test
+    void calculatesStandingsWithExtendedStats() {
+        League league = new League();
+        league.setSeason("2025");
+        ReflectionTestUtils.setField(league, "id", 1L);
+
+        Team valur = new Team();
+        valur.setName("Valur");
+        ReflectionTestUtils.setField(valur, "id", 100L);
+
+        Team kr = new Team();
+        kr.setName("KR");
+        ReflectionTestUtils.setField(kr, "id", 200L);
+
+        when(leagueRepository.findById(1L)).thenReturn(Optional.of(league));
+        when(teamRepository.findByLeagueId(1L)).thenReturn(List.of(valur, kr));
+
+        Game g1 = finalGame(league, valur, kr, 88, 80);
+        Game g2 = finalGame(league, kr, valur, 70, 85);
+        when(gameRepository.findByLeagueIdAndStatus(1L, Game.Status.FINAL)).thenReturn(List.of(g1, g2));
+
+        List<StandingDto> standings = service.getStandings(1L, "2025");
+
+        assertThat(standings).hasSize(2);
+        StandingDto leader = standings.get(0);
+        assertThat(leader.teamName()).isEqualTo("Valur");
+        assertThat(leader.wins()).isEqualTo(2);
+        assertThat(leader.losses()).isZero();
+        assertThat(leader.gamesPlayed()).isEqualTo(2);
+        assertThat(leader.pointsFor()).isEqualTo(173);
+        assertThat(leader.pointsAgainst()).isEqualTo(150);
+        assertThat(leader.winPct()).isEqualTo(1.0d);
+
+        StandingDto runnerUp = standings.get(1);
+        assertThat(runnerUp.teamName()).isEqualTo("KR");
+        assertThat(runnerUp.wins()).isZero();
+        assertThat(runnerUp.losses()).isEqualTo(2);
+        assertThat(runnerUp.pointsFor()).isEqualTo(150);
+    }
+
+    @Test
+    void rejectsSeasonMismatch() {
+        League league = new League();
+        league.setSeason("2025");
+        ReflectionTestUtils.setField(league, "id", 1L);
+        when(leagueRepository.findById(1L)).thenReturn(Optional.of(league));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.getStandings(1L, "2024"));
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private Game finalGame(League league, Team home, Team away, int homeScore, int awayScore) {
+        Game game = new Game();
+        game.setLeague(league);
+        game.setHomeTeam(home);
+        game.setAwayTeam(away);
+        game.setTipoff(LocalDateTime.now());
+        game.setStatus(Game.Status.FINAL);
+        game.setHomeScore(homeScore);
+        game.setAwayScore(awayScore);
+        return game;
+    }
+}

--- a/src/test/java/is/hi/basketmob/service/NotificationServiceTest.java
+++ b/src/test/java/is/hi/basketmob/service/NotificationServiceTest.java
@@ -1,0 +1,86 @@
+package is.hi.basketmob.service;
+
+import is.hi.basketmob.entity.Favorite;
+import is.hi.basketmob.entity.Game;
+import is.hi.basketmob.entity.League;
+import is.hi.basketmob.entity.Notification;
+import is.hi.basketmob.entity.Team;
+import is.hi.basketmob.entity.User;
+import is.hi.basketmob.notification.GameUpdatePublisher;
+import is.hi.basketmob.repository.FavoriteRepository;
+import is.hi.basketmob.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    private NotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationService(notificationRepository, favoriteRepository, new GameUpdatePublisher());
+    }
+
+    @Test
+    void createsNotificationForFollowersWhenGameEnds() {
+        Team valur = team(10L, "Valur");
+        Team kr = team(20L, "KR");
+        Game finalGame = new Game();
+        finalGame.setLeague(new League());
+        finalGame.setHomeTeam(valur);
+        finalGame.setAwayTeam(kr);
+        finalGame.setTipoff(LocalDateTime.now());
+        finalGame.setStatus(Game.Status.FINAL);
+        finalGame.setHomeScore(90);
+        finalGame.setAwayScore(82);
+
+        Favorite adminFavorite = new Favorite(user(1L, "admin@basketmob.is"), valur);
+        Favorite tomasFavorite = new Favorite(user(2L, "tomas@example.com"), kr);
+        when(favoriteRepository.findByTeamIdIn(anyList())).thenReturn(List.of(adminFavorite, tomasFavorite));
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.onGameFinal(finalGame);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, times(2)).save(captor.capture());
+        List<Notification> saved = captor.getAllValues();
+        assertThat(saved).hasSize(2);
+        assertThat(saved.get(0).getMessage()).contains("Valur");
+        assertThat(saved.get(0).isReadFlag()).isFalse();
+    }
+
+    private Team team(Long id, String name) {
+        Team team = new Team();
+        team.setName(name);
+        ReflectionTestUtils.setField(team, "id", id);
+        return team;
+    }
+
+    private User user(Long id, String email) {
+        User user = new User();
+        user.setEmail(email);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
feat: Thymeleaf demo shell (home/games/standings/dashboard)

> Pair-programming note: Built jointly by @alexa + @tomasandri99 during our Nov 8–9 mobbing session. Tomas handled layout/content; I pushed.

## Summary
- Added ViewController + UiAccountController and Thymeleaf templates (index, games, standings, dashboard, nav, basic CSS).
- Pages call existing services so we can demo fixtures/standings without Postman.
- Navbar reflects auth state via UiModelAttributes.

## Verification
1. ./mvnw spring-boot:run
2. Visit http://localhost:8080/, /games, /standings, /dashboard (while logged in) to confirm data renders.

## Remaining gaps / next steps
- Need to commit the actual templates/static files (currently gitignored locally) so CI can render them.
- Hook notifications panel + favorites list into the dashboard once backend gaps close.
- README still references “A2 slice”; update after these PRs merge.